### PR TITLE
Reorder checks

### DIFF
--- a/src/main/java/witchinggadgets/client/ClientEventHandler.java
+++ b/src/main/java/witchinggadgets/client/ClientEventHandler.java
@@ -89,7 +89,7 @@ public class ClientEventHandler
 					event.toolTip.add(StatCollector.translateToLocal("wg.desc.infusionStabilizer"));
 
 		if(event.entityPlayer!=null)
-			if(ThaumcraftApiHelper.isResearchComplete(event.entityPlayer.getCommandSenderName(), "GEMCUTTING") && InfusedGemHandler.isGem(event.itemStack) && GuiScreen.isShiftKeyDown())
+			if(InfusedGemHandler.isGem(event.itemStack) && GuiScreen.isShiftKeyDown() && ThaumcraftApiHelper.isResearchComplete(event.entityPlayer.getCommandSenderName(), "GEMCUTTING"))
 			{
 				if(InfusedGemHandler.getNaturalAffinities(event.itemStack)!=null && InfusedGemHandler.getNaturalAffinities(event.itemStack).length>0)
 				{


### PR DESCRIPTION
Reduce NEI serach time by 30% for initial searches by only doing the research check if the item is actually a gem