### PR TITLE
Fix Mantle Of The Raven on ladders

### DIFF
--- a/src/main/java/witchinggadgets/common/items/baubles/ItemCloak.java
+++ b/src/main/java/witchinggadgets/common/items/baubles/ItemCloak.java
@@ -259,7 +259,7 @@ public class ItemCloak extends Item implements ITravellersGear, IActiveAbility, 
 						stack.getTagCompound().setBoolean("isSpectral",false);
 			if(subNames[stack.getItemDamage()].equals("raven"))
 			{
-				if(!player.onGround)
+				if(!player.onGround && !player.isOnLadder())
 				{
 					if(player.capabilities.isFlying || Hover.getHover(player.getEntityId()))
 					{


### PR DESCRIPTION
Previously, it was impossible to descend ladders while wearing the Mantle Of The Raven as you would get pushed upwards repeatedly. This change disables the mantle while on a ladder, solving the issue.