### PR TITLE
Update ContainerCuttingTable.java

### DIFF
--- a/src/main/java/witchinggadgets/common/gui/ContainerCuttingTable.java
+++ b/src/main/java/witchinggadgets/common/gui/ContainerCuttingTable.java
@@ -28,7 +28,7 @@ public class ContainerCuttingTable extends Container {
                     if (stack == null) return true;
                     if (stack.hasTagCompound()) {
                         if (stack.getItem() == ConfigItems.itemEssence
-                                || stack.getItem().equals(ConfigItems.itemWispEssence)) {
+                                || stack.getItem() == ConfigItems.itemWispEssence) {
                             AspectList aspects = new AspectList();
                             aspects.readFromNBT(stack.getTagCompound());
                             return tileEntity.canAcceptAspect(aspects.getAspectsSortedAmount()[0]);

--- a/src/main/java/witchinggadgets/common/gui/ContainerCuttingTable.java
+++ b/src/main/java/witchinggadgets/common/gui/ContainerCuttingTable.java
@@ -26,11 +26,13 @@ public class ContainerCuttingTable extends Container {
                 @Override
                 public boolean isItemValid(ItemStack stack) {
                     if (stack == null) return true;
-                    if (stack.getItem().equals(ConfigItems.itemEssence)
-                            || stack.getItem().equals(ConfigItems.itemWispEssence)) {
-                        AspectList aspects = new AspectList();
-                        aspects.readFromNBT(stack.getTagCompound());
-                        return tileEntity.canAcceptAspect(aspects.getAspectsSortedAmount()[0]);
+                    if (stack.hasTagCompound()) {
+                        if (stack.getItem().equals(ConfigItems.itemEssence)
+                                || stack.getItem().equals(ConfigItems.itemWispEssence)) {
+                            AspectList aspects = new AspectList();
+                            aspects.readFromNBT(stack.getTagCompound());
+                            return tileEntity.canAcceptAspect(aspects.getAspectsSortedAmount()[0]);
+                        }
                     }
                     return false;
                 }

--- a/src/main/java/witchinggadgets/common/gui/ContainerCuttingTable.java
+++ b/src/main/java/witchinggadgets/common/gui/ContainerCuttingTable.java
@@ -27,7 +27,7 @@ public class ContainerCuttingTable extends Container {
                 public boolean isItemValid(ItemStack stack) {
                     if (stack == null) return true;
                     if (stack.hasTagCompound()) {
-                        if (stack.getItem().equals(ConfigItems.itemEssence)
+                        if (stack.getItem() == ConfigItems.itemEssence
                                 || stack.getItem().equals(ConfigItems.itemWispEssence)) {
                             AspectList aspects = new AspectList();
                             aspects.readFromNBT(stack.getTagCompound());


### PR DESCRIPTION
wrapped aspect check inside of a check for CompoundTags; fixes the nullPointerException caused by putting in a phial that does not hold anything in it [a techicnal oversight on the original dev's part]