### PR TITLE
Fix item equality check

### DIFF
--- a/src/main/java/witchinggadgets/common/util/handler/EventHandler.java
+++ b/src/main/java/witchinggadgets/common/util/handler/EventHandler.java
@@ -332,19 +332,20 @@ public class EventHandler {
                             event.setCanceled(true);
                             itemWasPickedUp = true;
                             break;
-                        } else if (OreDictionary.itemMatches(inv[f], event.item.getEntityItem(), true)) {
-                            int fit = Math.min(
-                                    Math.min(64, inv[f].getMaxStackSize()) - inv[f].stackSize,
-                                    event.item.getEntityItem().stackSize);
-                            inv[f].stackSize += fit;
-                            event.item.getEntityItem().stackSize -= fit;
-                            if (event.item.getEntityItem().stackSize <= 0) {
-                                event.item.setDead();
-                                event.setCanceled(true);
-                                itemWasPickedUp = true;
-                                break;
-                            }
-                        }
+                        } else if (inv[f].isItemEqual(event.item.getEntityItem())
+                                && ItemStack.areItemStackTagsEqual(inv[f], event.item.getEntityItem())) {
+                                    int fit = Math.min(
+                                            Math.min(64, inv[f].getMaxStackSize()) - inv[f].stackSize,
+                                            event.item.getEntityItem().stackSize);
+                                    inv[f].stackSize += fit;
+                                    event.item.getEntityItem().stackSize -= fit;
+                                    if (event.item.getEntityItem().stackSize <= 0) {
+                                        event.item.setDead();
+                                        event.setCanceled(true);
+                                        itemWasPickedUp = true;
+                                        break;
+                                    }
+                                }
                     }
                     ItemBag.setStoredItems(event.entityPlayer.inventory.getStackInSlot(i), inv);
                     if (itemWasPickedUp) {


### PR DESCRIPTION
Note that there is a change in behaviour, as previously the bag would merge items that ore dict into the same thing. If it's desired to keep this behaviour, let me know and I can adjust the check.

Fixes:
 * https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/87