### PR TITLE
Fix terra primordial regen

### DIFF
--- a/src/main/java/witchinggadgets/common/items/armor/ItemPrimordialArmor.java
+++ b/src/main/java/witchinggadgets/common/items/armor/ItemPrimordialArmor.java
@@ -493,7 +493,7 @@ public class ItemPrimordialArmor extends ItemShadowFortressArmor
                     break;
                 }
                 case 2:
-                    player.addPotionEffect(new PotionEffect(Potion.heal.id, 202, modescounter[1], true));
+                    player.addPotionEffect(new PotionEffect(Potion.regeneration.id, 202, 1 + modescounter[1], true));
                     break;
                 case 3: {
                     if (event.source.getSourceOfDamage() instanceof EntityLivingBase) {


### PR DESCRIPTION
fixes (and thus nerfs) the op regen that terra affinity primordial armor provides.

It was giving (upto) instant health 5 but over time for some reason, which then applies that every tick resulting in hundreds of health per second. I replaced that with a buffed up regen effect ranging all above the usual potion range so that terra is still good. Specifically from level III with 1 item to the maximum vanilla code can handle of VI with 4 items. That means with all 4 items having terra affinity the player still regens 20 health per second (!) for 10 seconds after being hit. Note that regen scales exponentially with effect level, see https://minecraft.fandom.com/wiki/Regeneration. If that is considered too strong I can tone it down a bit but I think it would be nice to keep something strong here.


fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10656 and fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8202

I also tested triggering the regen VI in the full game and it works as advertised