### PR TITLE
Fix Gauntlet container lock

### DIFF
--- a/src/main/java/witchinggadgets/common/gui/ContainerPrimordialGlove.java
+++ b/src/main/java/witchinggadgets/common/gui/ContainerPrimordialGlove.java
@@ -27,7 +27,9 @@ public class ContainerPrimordialGlove extends Container {
         this.worldObj = world;
         this.player = iinventory.player;
         this.bracelet = iinventory.getCurrentItem();
-        this.blockedSlot = (iinventory.currentItem + 45);
+        this.blockedSlot = (iinventory.currentItem + slotAmount
+                + iinventory.mainInventory.length
+                - InventoryPlayer.getHotbarSize());
 
         this.addSlotToContainer(new SlotInfusedGem(this.input, 0, 60, 06));
         this.addSlotToContainer(new SlotInfusedGem(this.input, 1, 100, 06));


### PR DESCRIPTION
In Primordial Gauntlet GUI, we can move the gauntlet itself. This spec causes item duplication or overwriting.
Gauntlet Container has a slot-locking system, but it doesn't work because the index is inappropriate.
This PR fixes the index of the locked slot.