### PR TITLE
Make Vambraces of Steady Progression not push the player up/down when the player is flying

### DIFF
--- a/src/main/java/witchinggadgets/common/items/baubles/ItemMagicalBaubles.java
+++ b/src/main/java/witchinggadgets/common/items/baubles/ItemMagicalBaubles.java
@@ -204,7 +204,10 @@ public class ItemMagicalBaubles extends Item
             onItemEquipped(living, stack);
         }
 
-        if (stack.getItemDamage() == 3 && living.isOnLadder()) {
+        EntityPlayer player = (EntityPlayer)living;
+        final bool isFlying = player && player.capabilities.isFlying;
+
+        if (stack.getItemDamage() == 3 && living.isOnLadder() && !isFlying) {
             if (living.isCollidedHorizontally) living.moveEntity(0, .25, 0);
             else if (!living.isSneaking()) living.moveEntity(0, -.1875, 0);
         }

--- a/src/main/java/witchinggadgets/common/items/baubles/ItemMagicalBaubles.java
+++ b/src/main/java/witchinggadgets/common/items/baubles/ItemMagicalBaubles.java
@@ -204,12 +204,13 @@ public class ItemMagicalBaubles extends Item
             onItemEquipped(living, stack);
         }
 
-        EntityPlayer player = (EntityPlayer)living;
-        final bool isFlying = player && player.capabilities.isFlying;
-
-        if (stack.getItemDamage() == 3 && living.isOnLadder() && !isFlying) {
-            if (living.isCollidedHorizontally) living.moveEntity(0, .25, 0);
-            else if (!living.isSneaking()) living.moveEntity(0, -.1875, 0);
+        if (stack.getItemDamage() == 3 && living.isOnLadder()) {
+            final bool isFlying = living instanceof EntityPlayer && (EntityPlayer)living.capabilities.isFlying;
+            if (!isFlying)
+            {
+                if (living.isCollidedHorizontally) living.moveEntity(0, .25, 0);
+                else if (!living.isSneaking()) living.moveEntity(0, -.1875, 0);
+            }
         }
     }
 

--- a/src/main/java/witchinggadgets/common/items/baubles/ItemMagicalBaubles.java
+++ b/src/main/java/witchinggadgets/common/items/baubles/ItemMagicalBaubles.java
@@ -205,9 +205,8 @@ public class ItemMagicalBaubles extends Item
         }
 
         if (stack.getItemDamage() == 3 && living.isOnLadder()) {
-            final bool isFlying = living instanceof EntityPlayer && (EntityPlayer)living.capabilities.isFlying;
-            if (!isFlying)
-            {
+            final boolean isFlying = living instanceof EntityPlayer && ((EntityPlayer) living).capabilities.isFlying;
+            if (!isFlying) {
                 if (living.isCollidedHorizontally) living.moveEntity(0, .25, 0);
                 else if (!living.isSneaking()) living.moveEntity(0, -.1875, 0);
             }


### PR DESCRIPTION
What it says on the tin: If the player is flying, then suppress the ladder "speed" adjustments.  Fixes the player being pushed down when flying forward into certain blocks, like ME Cables.