### PR TITLE
allow infernal blast furnace to drain essentia via mirrors

### DIFF
--- a/src/main/java/witchinggadgets/common/blocks/tiles/TileEntityBlastfurnace.java
+++ b/src/main/java/witchinggadgets/common/blocks/tiles/TileEntityBlastfurnace.java
@@ -134,9 +134,9 @@ public class TileEntityBlastfurnace extends TileEntityWGBase implements IEssenti
             for (int y = this.yCoord - 5; y < this.yCoord + 5; y++) {
                 for (int z = this.zCoord - 5; z < this.zCoord + 5; z++) {
                     TileEntity tile = this.worldObj.getTileEntity(x, y, z);
-                    if ((tile != null) && ((tile instanceof IAspectSource))) {
+                    if (tile instanceof IAspectSource) {
                         IAspectSource as = (IAspectSource) tile;
-                        if ((as.doesContainerContainAmount(Aspect.FIRE, 1)) && (as.takeFromContainer(Aspect.FIRE, 1))) {
+                        if (as.takeFromContainer(Aspect.FIRE, 1)) {
                             PacketHandler.INSTANCE.sendToAllAround(
                                     new PacketFXEssentiaSource(
                                             this.xCoord,


### PR DESCRIPTION
essentia mirrors never reports accessible content, as it could be an expensive operation, so IBF cannot drain from essentia mirror. this is slightly silly and we shall just fix it.