### PR TITLE
Fixed sync issue with Raven Kama glide toggle

### DIFF
--- a/src/main/java/witchinggadgets/common/items/baubles/ItemKama.java
+++ b/src/main/java/witchinggadgets/common/items/baubles/ItemKama.java
@@ -11,7 +11,9 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 
 import baubles.api.BaubleType;
+import baubles.api.BaublesApi;
 import baubles.api.IBauble;
+import baubles.common.container.InventoryBaubles;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -24,6 +26,16 @@ public class ItemKama extends ItemCloak implements IBauble {
 
     public ItemKama() {
         super();
+    }
+
+    @Override
+    public void activate(EntityPlayer player, ItemStack stack) {
+        super.activate(player, stack);
+        // 13116: Synchronize raven kama for client-authoritative player movement
+        if (subNames[stack.getItemDamage()].equals("raven") && !player.worldObj.isRemote) {
+            InventoryBaubles baubles = (InventoryBaubles) BaublesApi.getBaubles(player);
+            baubles.syncSlotToClients(3);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #13116

Because movement is client-authoritative in Minecraft and toggling the Raven Kama changes its server-side state, the toggle would not propagate to actually change movement. This did not affect the Raven Cloak because Traveller's Gear handles its own slots differently than Baubles does. Baubles inventory screen is created from the serverside ItemStacks, hence item appeared synced even though it wasn't.

Fixed by syncing the Baubles inventory belt slot when the Raven Kama is toggled.

![image](https://github.com/GTNewHorizons/WitchingGadgets/assets/55840769/35432ab2-805f-413b-8547-9b9c7eb45731)
