### PR TITLE
Blacklist Thaumcraft clusters + made the file more readable

### DIFF
--- a/src/main/java/witchinggadgets/common/WGContent.java
+++ b/src/main/java/witchinggadgets/common/WGContent.java
@@ -186,13 +186,23 @@ public class WGContent {
         preInitItems();
         preInitBlocks();
     }
+
+    private static boolean clusterBlacklist(Materials material) {
+        return material.equals(Materials.Cinnabar) || material.equals(Materials.Iron)
+                || material.equals(Materials.Gold)
+                || material.equals(Materials.Tin)
+                || material.equals(Materials.Copper)
+                || material.equals(Materials.Silver)
+                || material.equals(Materials.Lead);
+    }
+
     // final static String UUIDBASE = "424C5553-5747-1694-4452-";
 
     private static void initClusters() {
         HashSet<String> L = new HashSet<>();
         for (Entry<String, Materials> entry : Materials.getMaterialsMap().entrySet()) {
             Materials material = entry.getValue();
-            if (!b.contains(material.mDefaultLocalName)
+            if (!b.contains(material.mDefaultLocalName) && !clusterBlacklist(material)
                     && !OreDictionary.getOres("ore" + material.mDefaultLocalName.replaceAll(" ", "")).isEmpty()) {
                 Integer rgb = ((material.getRGBA()[0] & 0x0ff) << 16) | ((material.getRGBA()[1] & 0x0ff) << 8)
                         | (material.getRGBA()[2] & 0x0ff);

--- a/src/main/java/witchinggadgets/common/WGContent.java
+++ b/src/main/java/witchinggadgets/common/WGContent.java
@@ -188,12 +188,12 @@ public class WGContent {
     }
 
     private static boolean clusterBlacklist(Materials material) {
-        return material.equals(Materials.Cinnabar) || material.equals(Materials.Iron)
-                || material.equals(Materials.Gold)
+        return material.equals(Materials.Iron) || material.equals(Materials.Copper)
                 || material.equals(Materials.Tin)
-                || material.equals(Materials.Copper)
                 || material.equals(Materials.Silver)
-                || material.equals(Materials.Lead);
+                || material.equals(Materials.Lead)
+                || material.equals(Materials.Cinnabar)
+                || material.equals(Materials.Gold);
     }
 
     // final static String UUIDBASE = "424C5553-5747-1694-4452-";

--- a/src/main/java/witchinggadgets/common/WGResearch.java
+++ b/src/main/java/witchinggadgets/common/WGResearch.java
@@ -624,7 +624,8 @@ public class WGResearch {
         // PURECINNABAR
         researchAspects = new AspectList().add(Aspect.METAL, 5).add(Aspect.ORDER, 1).add(Aspect.POISON, 1);
         pages = new ResearchPage[] { new ResearchPage("witchinggadgets_research_page.PURECINNABAR.1"),
-                new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PURECINNABAR")) };
+                new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PURECINNABAR")),
+                new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PURECINNABAR.2")) };
         getResearchItem(
                 "PURECINNABAR",
                 "WITCHGADG",

--- a/src/main/java/witchinggadgets/common/recipes/WGResearchUtils.java
+++ b/src/main/java/witchinggadgets/common/recipes/WGResearchUtils.java
@@ -1,0 +1,85 @@
+package witchinggadgets.common.recipes;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.CraftingManager;
+import net.minecraft.item.crafting.IRecipe;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import gregtech.api.util.GTUtility;
+import thaumcraft.api.ThaumcraftApi;
+import thaumcraft.api.crafting.CrucibleRecipe;
+import thaumcraft.api.crafting.IArcaneRecipe;
+import thaumcraft.api.crafting.InfusionRecipe;
+import thaumcraft.api.research.ResearchCategories;
+import thaumcraft.api.research.ResearchItem;
+import thaumcraft.api.research.ResearchPage;
+
+public class WGResearchUtils {
+
+    public static void addResearchPage(final String research, ResearchPage page) {
+        ResearchItem ri = ResearchCategories.getResearch(research);
+        ri.setPages(ArrayUtils.add(ri.getPages(), page));
+    }
+
+    public static void refreshResearchPages(final String research) {
+        ResearchItem target = ResearchCategories.getResearch(research);
+        ResearchPage[] pages = target.getPages();
+        for (int x = 0; x < pages.length; x++) {
+            if (pages[x].recipe != null) {
+                if (pages[x].recipe instanceof IRecipe) {
+                    IRecipe recipe = (IRecipe) pages[x].recipe;
+                    for (Object craft : CraftingManager.getInstance().getRecipeList()) {
+                        if (craft instanceof IRecipe) {
+                            IRecipe theCraft = (IRecipe) craft;
+                            if (theCraft.getRecipeOutput() != null
+                                    && GTUtility.areStacksEqual(theCraft.getRecipeOutput(), recipe.getRecipeOutput())) {
+                                pages[x] = new ResearchPage(theCraft);
+                                break;
+                            }
+                        }
+                    }
+                } else if (pages[x].recipe instanceof IArcaneRecipe) {
+                    IArcaneRecipe recipe = (IArcaneRecipe) pages[x].recipe;
+                    for (Object craft : ThaumcraftApi.getCraftingRecipes()) {
+                        if (craft instanceof IArcaneRecipe) {
+                            IArcaneRecipe theCraft = (IArcaneRecipe) craft;
+                            if (theCraft.getRecipeOutput() != null
+                                    && GTUtility.areStacksEqual(theCraft.getRecipeOutput(), recipe.getRecipeOutput())) {
+                                pages[x] = new ResearchPage(theCraft);
+                                break;
+                            }
+                        }
+                    }
+                } else if (pages[x].recipe instanceof CrucibleRecipe) {
+                    CrucibleRecipe recipe = (CrucibleRecipe) pages[x].recipe;
+                    for (Object craft : ThaumcraftApi.getCraftingRecipes()) {
+                        if (craft instanceof CrucibleRecipe) {
+                            CrucibleRecipe theCraft = (CrucibleRecipe) craft;
+                            if (theCraft.getRecipeOutput() != null
+                                    && GTUtility.areStacksEqual(theCraft.getRecipeOutput(), recipe.getRecipeOutput())) {
+                                pages[x] = new ResearchPage(theCraft);
+                                break;
+                            }
+                        }
+                    }
+                } else if (pages[x].recipe instanceof InfusionRecipe) {
+                    InfusionRecipe recipe = (InfusionRecipe) pages[x].recipe;
+                    if (recipe.getRecipeOutput() instanceof ItemStack) {
+                        for (Object craft : ThaumcraftApi.getCraftingRecipes()) {
+                            if (craft instanceof InfusionRecipe) {
+                                InfusionRecipe theCraft = (InfusionRecipe) craft;
+                                if (theCraft.getRecipeOutput() instanceof ItemStack && GTUtility.areStacksEqual(
+                                        ((ItemStack) theCraft.getRecipeOutput()),
+                                        (ItemStack) recipe.getRecipeOutput())) {
+                                    pages[x] = new ResearchPage(theCraft);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/witchinggadgets/common/recipes/WG_alchemic_recipes.java
+++ b/src/main/java/witchinggadgets/common/recipes/WG_alchemic_recipes.java
@@ -2,15 +2,10 @@ package witchinggadgets.common.recipes;
 
 import net.minecraft.item.ItemStack;
 
-import org.apache.commons.lang3.ArrayUtils;
-
 import gregtech.api.util.GTUtility;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.crafting.CrucibleRecipe;
-import thaumcraft.api.research.ResearchCategories;
-import thaumcraft.api.research.ResearchItem;
-import thaumcraft.api.research.ResearchPage;
 import witchinggadgets.common.WGConfig;
 import witchinggadgets.common.WGContent;
 import witchinggadgets.common.recipes.alchemic.WG_alchemic_clusters;
@@ -52,10 +47,5 @@ public class WG_alchemic_recipes {
                     && GTUtility.areStacksEqual(((CrucibleRecipe) recipe).getRecipeOutput(), output);
             return false;
         });
-    }
-
-    public static void addResearchPage(final String research, ResearchPage page) {
-        ResearchItem ri = ResearchCategories.getResearch(research);
-        ri.setPages(ArrayUtils.add(ri.getPages(), page));
     }
 }

--- a/src/main/java/witchinggadgets/common/recipes/WG_alchemic_recipes.java
+++ b/src/main/java/witchinggadgets/common/recipes/WG_alchemic_recipes.java
@@ -1,9 +1,10 @@
 package witchinggadgets.common.recipes;
 
-import gregtech.api.util.GTUtility;
 import net.minecraft.item.ItemStack;
 
 import org.apache.commons.lang3.ArrayUtils;
+
+import gregtech.api.util.GTUtility;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.crafting.CrucibleRecipe;

--- a/src/main/java/witchinggadgets/common/recipes/WG_alchemic_recipes.java
+++ b/src/main/java/witchinggadgets/common/recipes/WG_alchemic_recipes.java
@@ -1,16 +1,22 @@
 package witchinggadgets.common.recipes;
 
+import gregtech.api.util.GTUtility;
 import net.minecraft.item.ItemStack;
 
+import org.apache.commons.lang3.ArrayUtils;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.crafting.CrucibleRecipe;
+import thaumcraft.api.research.ResearchCategories;
+import thaumcraft.api.research.ResearchItem;
+import thaumcraft.api.research.ResearchPage;
 import witchinggadgets.common.WGConfig;
 import witchinggadgets.common.WGContent;
 import witchinggadgets.common.recipes.alchemic.WG_alchemic_clusters;
 import witchinggadgets.common.recipes.alchemic.WG_alchemic_crystal_capsule;
 import witchinggadgets.common.recipes.alchemic.WG_alchemic_pure_cinnabar;
 import witchinggadgets.common.recipes.alchemic.WG_alchemic_rose_vine;
+import witchinggadgets.common.recipes.alchemic.WG_alchemic_tc_clusters;
 import witchinggadgets.common.recipes.alchemic.WG_alchemic_transmogrify;
 
 public class WG_alchemic_recipes {
@@ -28,6 +34,7 @@ public class WG_alchemic_recipes {
         }
 
         WG_alchemic_clusters.registerClusters();
+        WG_alchemic_tc_clusters.registerExistingClusters();
 
     }
 
@@ -36,5 +43,18 @@ public class WG_alchemic_recipes {
         CrucibleRecipe crucibleRecipe = ThaumcraftApi.addCrucibleRecipe(tag, result, catalyst, alchemyAspects);
         WGContent.recipeList.put(tag + tagAddon, crucibleRecipe);
         return crucibleRecipe;
+    }
+
+    public static void removeCrucibleRecipe(final ItemStack output) {
+        ThaumcraftApi.getCraftingRecipes().removeIf(recipe -> {
+            if (recipe instanceof CrucibleRecipe) return ((CrucibleRecipe) recipe).getRecipeOutput() != null
+                    && GTUtility.areStacksEqual(((CrucibleRecipe) recipe).getRecipeOutput(), output);
+            return false;
+        });
+    }
+
+    public static void addResearchPage(final String research, ResearchPage page) {
+        ResearchItem ri = ResearchCategories.getResearch(research);
+        ri.setPages(ArrayUtils.add(ri.getPages(), page));
     }
 }

--- a/src/main/java/witchinggadgets/common/recipes/alchemic/WG_alchemic_clusters.java
+++ b/src/main/java/witchinggadgets/common/recipes/alchemic/WG_alchemic_clusters.java
@@ -31,15 +31,12 @@ public class WG_alchemic_clusters {
         AspectList alchemyAspects;
 
         if (Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi")) {
-            for (int iOre = 0; iOre < witchinggadgets.common.WGContent.GT_Cluster.length; iOre++) {
+            for (int iOre = 0; iOre < WGContent.GT_Cluster.length; iOre++) {
                 if (WGConfig.allowClusters) {
-                    ItemStack ingot = OreDictionary.getOres("ore" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                            .get(0);
+                    ItemStack ingot = OreDictionary.getOres("ore" + WGContent.GT_Cluster[iOre]).get(0);
 
                     if (ingot == null) {
-                        WitchingGadgets.logger.error(
-                                witchinggadgets.common.WGContent.GT_Cluster[iOre]
-                                        + " == null! This should not happen!");
+                        WitchingGadgets.logger.error(WGContent.GT_Cluster[iOre] + " == null! This should not happen!");
                         continue;
                     }
 
@@ -47,8 +44,7 @@ public class WG_alchemic_clusters {
                         alchemyAspects = ThaumcraftApi.objectTags
                                 .get(Arrays.asList(ingot.getItem(), ingot.getItemDamage())).add(Aspect.ORDER, 1);
                     } catch (NullPointerException e) {
-                        WitchingGadgets.logger.error(
-                                "Could not get the objectTags for" + witchinggadgets.common.WGContent.GT_Cluster[iOre]);
+                        WitchingGadgets.logger.error("Could not get the objectTags for" + WGContent.GT_Cluster[iOre]);
                         alchemyAspects = new AspectList().add(Aspect.METAL, 2).add(Aspect.ORDER, 1)
                                 .add((Aspect) gregtech.api.enums.TCAspects.NEBRISUM.mAspect, 2);
                     }
@@ -63,119 +59,96 @@ public class WG_alchemic_clusters {
                     else if (alchemyAspects.size() > 6) alchemyAspects = new AspectList().add(Aspect.METAL, 2)
                             .add(Aspect.ORDER, 1).add(Aspect.GREED, 2);
 
-                    if (!OreDictionary.getOres("ore" + witchinggadgets.common.WGContent.GT_Cluster[iOre]).isEmpty())
+                    if (!OreDictionary.getOres("ore" + WGContent.GT_Cluster[iOre]).isEmpty()) registerAlchemyRecipe(
+                            "METALLURGICPERFECTION_CLUSTERS",
+                            "_" + WGContent.GT_Cluster[iOre],
+                            new ItemStack(WGContent.ItemCluster, 2, iOre),
+                            "ore" + WGContent.GT_Cluster[iOre],
+                            alchemyAspects);
+
+                    if (!OreDictionary.getOres("oreNetherrack" + WGContent.GT_Cluster[iOre]).isEmpty())
                         registerAlchemyRecipe(
                                 "METALLURGICPERFECTION_CLUSTERS",
-                                "_" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
-                                new ItemStack(witchinggadgets.common.WGContent.ItemCluster, 2, iOre),
-                                "ore" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
+                                "_Netherrack_" + WGContent.GT_Cluster[iOre],
+                                new ItemStack(WGContent.ItemCluster, 4, iOre),
+                                "oreNetherrack" + WGContent.GT_Cluster[iOre],
                                 alchemyAspects);
 
-                    if (!OreDictionary.getOres("oreNetherrack" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                            .isEmpty())
+                    if (!OreDictionary.getOres("oreEndstone" + WGContent.GT_Cluster[iOre]).isEmpty())
                         registerAlchemyRecipe(
                                 "METALLURGICPERFECTION_CLUSTERS",
-                                "_Netherrack_" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
-                                new ItemStack(witchinggadgets.common.WGContent.ItemCluster, 4, iOre),
-                                "oreNetherrack" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
-                                alchemyAspects);
-
-                    if (!OreDictionary.getOres("oreEndstone" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                            .isEmpty())
-                        registerAlchemyRecipe(
-                                "METALLURGICPERFECTION_CLUSTERS",
-                                "_Endstone_" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
-                                new ItemStack(witchinggadgets.common.WGContent.ItemCluster, 4, iOre),
-                                "oreEndstone" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
+                                "_Endstone_" + WGContent.GT_Cluster[iOre],
+                                new ItemStack(WGContent.ItemCluster, 4, iOre),
+                                "oreEndstone" + WGContent.GT_Cluster[iOre],
                                 alchemyAspects).hash += 1;
 
-                    if (!OreDictionary.getOres("oreBlackgranite" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                            .isEmpty())
+                    if (!OreDictionary.getOres("oreBlackgranite" + WGContent.GT_Cluster[iOre]).isEmpty())
                         registerAlchemyRecipe(
                                 "METALLURGICPERFECTION_CLUSTERS",
-                                "_Blackgranite_" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
-                                new ItemStack(witchinggadgets.common.WGContent.ItemCluster, 2, iOre),
-                                "oreBlackgranite" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
+                                "_Blackgranite_" + WGContent.GT_Cluster[iOre],
+                                new ItemStack(WGContent.ItemCluster, 2, iOre),
+                                "oreBlackgranite" + WGContent.GT_Cluster[iOre],
                                 alchemyAspects).hash += 1;
 
-                    if (!OreDictionary.getOres("oreRedgranite" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                            .isEmpty())
+                    if (!OreDictionary.getOres("oreRedgranite" + WGContent.GT_Cluster[iOre]).isEmpty())
                         registerAlchemyRecipe(
                                 "METALLURGICPERFECTION_CLUSTERS",
-                                "_Redgranite_" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
-                                new ItemStack(witchinggadgets.common.WGContent.ItemCluster, 2, iOre),
-                                "oreRedgranite" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
+                                "_Redgranite_" + WGContent.GT_Cluster[iOre],
+                                new ItemStack(WGContent.ItemCluster, 2, iOre),
+                                "oreRedgranite" + WGContent.GT_Cluster[iOre],
                                 alchemyAspects).hash += 2;
 
-                    if (!OreDictionary.getOres("oreMarble" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                            .isEmpty())
+                    if (!OreDictionary.getOres("oreMarble" + WGContent.GT_Cluster[iOre]).isEmpty())
                         registerAlchemyRecipe(
                                 "METALLURGICPERFECTION_CLUSTERS",
-                                "_Marble_" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
-                                new ItemStack(witchinggadgets.common.WGContent.ItemCluster, 2, iOre),
-                                "oreMarble" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
+                                "_Marble_" + WGContent.GT_Cluster[iOre],
+                                new ItemStack(WGContent.ItemCluster, 2, iOre),
+                                "oreMarble" + WGContent.GT_Cluster[iOre],
                                 alchemyAspects).hash += 3;
 
-                    if (!OreDictionary.getOres("oreBasalt" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                            .isEmpty())
+                    if (!OreDictionary.getOres("oreBasalt" + WGContent.GT_Cluster[iOre]).isEmpty())
                         registerAlchemyRecipe(
                                 "METALLURGICPERFECTION_CLUSTERS",
-                                "_Basalt_" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
-                                new ItemStack(witchinggadgets.common.WGContent.ItemCluster, 2, iOre),
-                                "oreBasalt" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
+                                "_Basalt_" + WGContent.GT_Cluster[iOre],
+                                new ItemStack(WGContent.ItemCluster, 2, iOre),
+                                "oreBasalt" + WGContent.GT_Cluster[iOre],
                                 alchemyAspects).hash += 4;
 
-                    if (!OreDictionary.getOres("rawOre" + witchinggadgets.common.WGContent.GT_Cluster[iOre]).isEmpty())
-                        registerAlchemyRecipe(
-                                "METALLURGICPERFECTION_CLUSTERS",
-                                "_Raw_" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
-                                new ItemStack(witchinggadgets.common.WGContent.ItemCluster, 2, iOre),
-                                "rawOre" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
-                                alchemyAspects).hash += 5;
+                    if (!OreDictionary.getOres("rawOre" + WGContent.GT_Cluster[iOre]).isEmpty()) registerAlchemyRecipe(
+                            "METALLURGICPERFECTION_CLUSTERS",
+                            "_Raw_" + WGContent.GT_Cluster[iOre],
+                            new ItemStack(WGContent.ItemCluster, 2, iOre),
+                            "rawOre" + WGContent.GT_Cluster[iOre],
+                            alchemyAspects).hash += 5;
                     // I blame Bart.
-                    if (!OreDictionary.getOres("ore" + witchinggadgets.common.WGContent.GT_Cluster[iOre]).isEmpty()
-                            || !OreDictionary
-                                    .getOres("oreNetherrack" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                                    .isEmpty()
-                            || !OreDictionary.getOres("oreEndstone" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                                    .isEmpty()
-                            || !OreDictionary
-                                    .getOres("oreBlackgranite" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                                    .isEmpty()
-                            || !OreDictionary
-                                    .getOres("oreRedgranite" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                                    .isEmpty()
-                            || !OreDictionary.getOres("oreMarble" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                                    .isEmpty()
-                            || !OreDictionary.getOres("oreBasalt" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                                    .isEmpty()
-                            || !OreDictionary.getOres("rawOre" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                                    .isEmpty())
+                    if (!OreDictionary.getOres("ore" + WGContent.GT_Cluster[iOre]).isEmpty()
+                            || !OreDictionary.getOres("oreNetherrack" + WGContent.GT_Cluster[iOre]).isEmpty()
+                            || !OreDictionary.getOres("oreEndstone" + WGContent.GT_Cluster[iOre]).isEmpty()
+                            || !OreDictionary.getOres("oreBlackgranite" + WGContent.GT_Cluster[iOre]).isEmpty()
+                            || !OreDictionary.getOres("oreRedgranite" + WGContent.GT_Cluster[iOre]).isEmpty()
+                            || !OreDictionary.getOres("oreMarble" + WGContent.GT_Cluster[iOre]).isEmpty()
+                            || !OreDictionary.getOres("oreBasalt" + WGContent.GT_Cluster[iOre]).isEmpty()
+                            || !OreDictionary.getOres("rawOre" + WGContent.GT_Cluster[iOre]).isEmpty())
 
-                        setupCluster(witchinggadgets.common.WGContent.GT_Cluster[iOre]);
+                        setupCluster(WGContent.GT_Cluster[iOre]);
                 }
                 if (WGConfig.allowTransmutations) {
-                    boolean bb = !OreDictionary.getOres("nugget" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                            .isEmpty()
-                            && !OreDictionary.getOres("ingot" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                                    .isEmpty();
+                    boolean bb = !OreDictionary.getOres("nugget" + WGContent.GT_Cluster[iOre]).isEmpty()
+                            && !OreDictionary.getOres("ingot" + WGContent.GT_Cluster[iOre]).isEmpty();
                     if (bb) {
-                        ItemStack ingot = OreDictionary
-                                .getOres("ingot" + witchinggadgets.common.WGContent.GT_Cluster[iOre]).get(0);
+                        ItemStack ingot = OreDictionary.getOres("ingot" + WGContent.GT_Cluster[iOre]).get(0);
 
                         if (ingot == null) {
-                            WitchingGadgets.logger.error(
-                                    witchinggadgets.common.WGContent.GT_Cluster[iOre]
-                                            + " == null! This should not happen!");
+                            WitchingGadgets.logger
+                                    .error(WGContent.GT_Cluster[iOre] + " == null! This should not happen!");
                             continue;
                         }
                         try {
                             alchemyAspects = ThaumcraftApi.objectTags
                                     .get(Arrays.asList(ingot.getItem(), ingot.getItemDamage())).add(Aspect.EXCHANGE, 1);
                         } catch (NullPointerException e) {
-                            WitchingGadgets.logger.error(
-                                    "Could not get the objectTags for"
-                                            + witchinggadgets.common.WGContent.GT_Cluster[iOre]);
+                            WitchingGadgets.logger
+                                    .error("Could not get the objectTags for" + WGContent.GT_Cluster[iOre]);
                             alchemyAspects = new AspectList().add(Aspect.METAL, 2).add(Aspect.ORDER, 1)
                                     .add((Aspect) gregtech.api.enums.TCAspects.NEBRISUM.mAspect, 2);
                         }
@@ -189,17 +162,16 @@ public class WG_alchemic_clusters {
                         alchemyAspects.aspects.entrySet()
                                 .removeIf(e -> e.getKey() == null || e.getValue() == null || e.getValue() <= 0);
                         int f = 0;
-                        ItemStack rawnuggets = OreDictionary
-                                .getOres("nugget" + witchinggadgets.common.WGContent.GT_Cluster[iOre]).get(f).copy();
+                        ItemStack rawnuggets = OreDictionary.getOres("nugget" + WGContent.GT_Cluster[iOre]).get(f)
+                                .copy();
                         if (rawnuggets.getDisplayName().contains("Oreberry")) ++f;
-                        rawnuggets = OreDictionary.getOres("nugget" + witchinggadgets.common.WGContent.GT_Cluster[iOre])
-                                .get(f).copy();
+                        rawnuggets = OreDictionary.getOres("nugget" + WGContent.GT_Cluster[iOre]).get(f).copy();
                         ItemStack nuggets = Utilities.copyStackWithSize(rawnuggets, 3);
                         registerAlchemyRecipe(
                                 "METALLURGICPERFECTION_TRANSMUTATION",
-                                "_" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
+                                "_" + WGContent.GT_Cluster[iOre],
                                 nuggets,
-                                "nugget" + witchinggadgets.common.WGContent.GT_Cluster[iOre],
+                                "nugget" + WGContent.GT_Cluster[iOre],
                                 alchemyAspects);
                     }
                 }

--- a/src/main/java/witchinggadgets/common/recipes/alchemic/WG_alchemic_pure_cinnabar.java
+++ b/src/main/java/witchinggadgets/common/recipes/alchemic/WG_alchemic_pure_cinnabar.java
@@ -14,16 +14,18 @@ public class WG_alchemic_pure_cinnabar {
         registerAlchemyRecipe(
                 "PURECINNABAR",
                 "",
-                new ItemStack(ConfigItems.itemNugget, 1, 21),
+                new ItemStack(ConfigItems.itemNugget, 2, 21),
                 "oreCinnabar",
-                new AspectList().add(Aspect.METAL, 1).add(Aspect.ORDER, 1));
+                new AspectList().add(Aspect.METAL, 2).add(Aspect.EXCHANGE, 2).add(Aspect.EARTH, 1).add(Aspect.POISON, 1)
+                        .add(Aspect.ORDER, 1));
 
         registerAlchemyRecipe(
                 "PURECINNABAR",
                 "",
-                new ItemStack(ConfigItems.itemNugget, 1, 21),
+                new ItemStack(ConfigItems.itemNugget, 2, 21),
                 "rawOreCinnabar",
-                new AspectList().add(Aspect.METAL, 1).add(Aspect.ORDER, 1));
+                new AspectList().add(Aspect.METAL, 2).add(Aspect.EXCHANGE, 2).add(Aspect.EARTH, 1).add(Aspect.POISON, 1)
+                        .add(Aspect.ORDER, 1));
 
     }
 

--- a/src/main/java/witchinggadgets/common/recipes/alchemic/WG_alchemic_pure_cinnabar.java
+++ b/src/main/java/witchinggadgets/common/recipes/alchemic/WG_alchemic_pure_cinnabar.java
@@ -21,6 +21,54 @@ public class WG_alchemic_pure_cinnabar {
 
         registerAlchemyRecipe(
                 "PURECINNABAR",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 4, 21),
+                "oreNetherrackCinnabar",
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.EXCHANGE, 4).add(Aspect.EARTH, 2).add(Aspect.POISON, 2)
+                        .add(Aspect.ORDER, 2));
+
+        registerAlchemyRecipe(
+                "PURECINNABAR",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 4, 21),
+                "oreEndstoneCinnabar",
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.EXCHANGE, 4).add(Aspect.EARTH, 2).add(Aspect.POISON, 2)
+                        .add(Aspect.ORDER, 2));
+
+        registerAlchemyRecipe(
+                "PURECINNABAR",
+                "",
+                new ItemStack(ConfigItems.itemNugget, 2, 21),
+                "oreBlackgraniteCinnabar",
+                new AspectList().add(Aspect.METAL, 2).add(Aspect.EXCHANGE, 2).add(Aspect.EARTH, 1).add(Aspect.POISON, 1)
+                        .add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURECINNABAR",
+                "",
+                new ItemStack(ConfigItems.itemNugget, 2, 21),
+                "oreRedgraniteCinnabar",
+                new AspectList().add(Aspect.METAL, 2).add(Aspect.EXCHANGE, 2).add(Aspect.EARTH, 1).add(Aspect.POISON, 1)
+                        .add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURECINNABAR",
+                "",
+                new ItemStack(ConfigItems.itemNugget, 2, 21),
+                "oreMarbleCinnabar",
+                new AspectList().add(Aspect.METAL, 2).add(Aspect.EXCHANGE, 2).add(Aspect.EARTH, 1).add(Aspect.POISON, 1)
+                        .add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURECINNABAR",
+                "",
+                new ItemStack(ConfigItems.itemNugget, 2, 21),
+                "oreBasaltCinnabar",
+                new AspectList().add(Aspect.METAL, 2).add(Aspect.EXCHANGE, 2).add(Aspect.EARTH, 1).add(Aspect.POISON, 1)
+                        .add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURECINNABAR",
                 "",
                 new ItemStack(ConfigItems.itemNugget, 2, 21),
                 "rawOreCinnabar",

--- a/src/main/java/witchinggadgets/common/recipes/alchemic/WG_alchemic_tc_clusters.java
+++ b/src/main/java/witchinggadgets/common/recipes/alchemic/WG_alchemic_tc_clusters.java
@@ -381,5 +381,4 @@ public class WG_alchemic_tc_clusters {
         addResearchPage("PUREGOLD", new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PUREGOLD.3")));
     }
 
-
 }

--- a/src/main/java/witchinggadgets/common/recipes/alchemic/WG_alchemic_tc_clusters.java
+++ b/src/main/java/witchinggadgets/common/recipes/alchemic/WG_alchemic_tc_clusters.java
@@ -1,0 +1,385 @@
+package witchinggadgets.common.recipes.alchemic;
+
+import static witchinggadgets.common.recipes.WG_alchemic_recipes.addResearchPage;
+import static witchinggadgets.common.recipes.WG_alchemic_recipes.registerAlchemyRecipe;
+import static witchinggadgets.common.recipes.WG_alchemic_recipes.removeCrucibleRecipe;
+
+import net.minecraft.item.ItemStack;
+
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.crafting.CrucibleRecipe;
+import thaumcraft.api.research.ResearchPage;
+import thaumcraft.common.config.ConfigItems;
+import witchinggadgets.common.WGContent;
+
+public class WG_alchemic_tc_clusters {
+
+    public static void registerExistingClusters() {
+        removeCrucibleRecipe(new ItemStack(ConfigItems.itemNugget, 1, 16)); // Iron
+        removeCrucibleRecipe(new ItemStack(ConfigItems.itemNugget, 1, 17)); // Copper
+        removeCrucibleRecipe(new ItemStack(ConfigItems.itemNugget, 1, 18)); // Tin
+        removeCrucibleRecipe(new ItemStack(ConfigItems.itemNugget, 1, 19)); // Silver
+        removeCrucibleRecipe(new ItemStack(ConfigItems.itemNugget, 1, 20)); // Lead
+        removeCrucibleRecipe(new ItemStack(ConfigItems.itemNugget, 1, 31)); // Gold
+
+        registerAlchemyRecipe(
+                "PUREIRON",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 16),
+                "oreIron",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PUREIRON",
+                ".3",
+                new ItemStack(ConfigItems.itemNugget, 4, 16),
+                "oreNetherrackIron",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PUREIRON",
+                ".3",
+                new ItemStack(ConfigItems.itemNugget, 4, 16),
+                "oreEndstoneIron",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PUREIRON",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 16),
+                "oreBlackgraniteIron",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PUREIRON",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 16),
+                "oreRedgraniteIron",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PUREIRON",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 16),
+                "oreMarbleIron",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PUREIRON",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 16),
+                "oreBasaltIron",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PUREIRON",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 16),
+                "rawOreIron",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        addResearchPage("PUREIRON", new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PUREIRON.3")));
+
+        registerAlchemyRecipe(
+                "PURECOPPER",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 17),
+                "oreCopper",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURECOPPER",
+                ".3",
+                new ItemStack(ConfigItems.itemNugget, 4, 17),
+                "oreNetherrackCopper",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURECOPPER",
+                ".3",
+                new ItemStack(ConfigItems.itemNugget, 4, 17),
+                "oreEndstoneCopper",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURECOPPER",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 17),
+                "oreBlackgraniteCopper",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURECOPPER",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 17),
+                "oreRedgraniteCopper",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURECOPPER",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 17),
+                "oreMarbleCopper",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURECOPPER",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 17),
+                "oreBasaltCopper",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURECOPPER",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 17),
+                "rawOreCopper",
+                new AspectList().add(Aspect.METAL, 2).add(Aspect.EARTH, 1).add(Aspect.EXCHANGE, 1)
+                        .add(Aspect.ORDER, 1));
+
+        addResearchPage("PURECOPPER", new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PURECOPPER.3")));
+
+        registerAlchemyRecipe(
+                "PURETIN",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 18),
+                "oreTin",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
+                        .add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURETIN",
+                ".3",
+                new ItemStack(ConfigItems.itemNugget, 4, 18),
+                "oreNetherrackTin",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
+                        .add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURETIN",
+                ".3",
+                new ItemStack(ConfigItems.itemNugget, 4, 18),
+                "oreEndstoneTin",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
+                        .add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURETIN",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 18),
+                "oreBlackgraniteTin",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
+                        .add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURETIN",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 18),
+                "oreRedgraniteTin",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
+                        .add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURETIN",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 18),
+                "oreMarbleTin",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
+                        .add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURETIN",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 18),
+                "oreBasaltTin",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
+                        .add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURETIN",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 18),
+                "rawOreTin",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
+                        .add(Aspect.ORDER, 1));
+
+        addResearchPage("PURETIN", new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PURETIN.3")));
+
+        registerAlchemyRecipe(
+                "PURESILVER",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 19),
+                "oreSilver",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURESILVER",
+                ".3",
+                new ItemStack(ConfigItems.itemNugget, 4, 19),
+                "oreNetherrackSilver",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURESILVER",
+                ".3",
+                new ItemStack(ConfigItems.itemNugget, 4, 19),
+                "oreEndstoneSilver",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURESILVER",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 19),
+                "oreBlackgraniteSilver",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURESILVER",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 19),
+                "oreRedgraniteSilver",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURESILVER",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 19),
+                "oreMarbleSilver",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURESILVER",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 19),
+                "oreBasaltSilver",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
+
+        registerAlchemyRecipe(
+                "PURESILVER",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 19),
+                "rawOreSilver",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
+
+        addResearchPage("PURESILVER", new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PURESILVER.3")));
+
+        registerAlchemyRecipe(
+                "PURELEAD",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 20),
+                "oreLead",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PURELEAD",
+                ".3",
+                new ItemStack(ConfigItems.itemNugget, 4, 20),
+                "oreNetherrackLead",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PURELEAD",
+                ".3",
+                new ItemStack(ConfigItems.itemNugget, 4, 20),
+                "oreEndstoneLead",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PURELEAD",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 20),
+                "oreBlackgraniteLead",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PURELEAD",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 20),
+                "oreRedgraniteLead",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PURELEAD",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 20),
+                "oreMarbleLead",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PURELEAD",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 20),
+                "oreBasaltLead",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PURELEAD",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 20),
+                "rawOreLead",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        addResearchPage("PURELEAD", new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PURELEAD.3")));
+
+        registerAlchemyRecipe(
+                "PUREGOLD",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 31),
+                "oreGold",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PUREGOLD",
+                ".3",
+                new ItemStack(ConfigItems.itemNugget, 4, 31),
+                "oreNetherrackGold",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PUREGOLD",
+                ".3",
+                new ItemStack(ConfigItems.itemNugget, 4, 31),
+                "oreEndstoneGold",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PUREGOLD",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 31),
+                "oreBlackgraniteGold",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PUREGOLD",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 31),
+                "oreRedgraniteGold",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PUREGOLD",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 31),
+                "oreMarbleGold",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PUREGOLD",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 31),
+                "oreBasaltGold",
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
+
+        registerAlchemyRecipe(
+                "PUREGOLD",
+                ".2",
+                new ItemStack(ConfigItems.itemNugget, 2, 31),
+                "rawOreGold",
+                new AspectList().add(Aspect.METAL, 2).add(Aspect.EARTH, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
+
+        addResearchPage("PUREGOLD", new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PUREGOLD.3")));
+    }
+
+
+}

--- a/src/main/java/witchinggadgets/common/recipes/alchemic/WG_alchemic_tc_clusters.java
+++ b/src/main/java/witchinggadgets/common/recipes/alchemic/WG_alchemic_tc_clusters.java
@@ -1,6 +1,7 @@
 package witchinggadgets.common.recipes.alchemic;
 
-import static witchinggadgets.common.recipes.WG_alchemic_recipes.addResearchPage;
+import static witchinggadgets.common.recipes.WGResearchUtils.addResearchPage;
+import static witchinggadgets.common.recipes.WGResearchUtils.refreshResearchPages;
 import static witchinggadgets.common.recipes.WG_alchemic_recipes.registerAlchemyRecipe;
 import static witchinggadgets.common.recipes.WG_alchemic_recipes.removeCrucibleRecipe;
 
@@ -25,7 +26,7 @@ public class WG_alchemic_tc_clusters {
 
         registerAlchemyRecipe(
                 "PUREIRON",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 16),
                 "oreIron",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
@@ -46,44 +47,45 @@ public class WG_alchemic_tc_clusters {
 
         registerAlchemyRecipe(
                 "PUREIRON",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 16),
                 "oreBlackgraniteIron",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
 
         registerAlchemyRecipe(
                 "PUREIRON",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 16),
                 "oreRedgraniteIron",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
 
         registerAlchemyRecipe(
                 "PUREIRON",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 16),
                 "oreMarbleIron",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
 
         registerAlchemyRecipe(
                 "PUREIRON",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 16),
                 "oreBasaltIron",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
 
         registerAlchemyRecipe(
                 "PUREIRON",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 16),
                 "rawOreIron",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
 
+        refreshResearchPages("PUREIRON");
         addResearchPage("PUREIRON", new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PUREIRON.3")));
 
         registerAlchemyRecipe(
                 "PURECOPPER",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 17),
                 "oreCopper",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
@@ -104,45 +106,46 @@ public class WG_alchemic_tc_clusters {
 
         registerAlchemyRecipe(
                 "PURECOPPER",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 17),
                 "oreBlackgraniteCopper",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
 
         registerAlchemyRecipe(
                 "PURECOPPER",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 17),
                 "oreRedgraniteCopper",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
 
         registerAlchemyRecipe(
                 "PURECOPPER",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 17),
                 "oreMarbleCopper",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
 
         registerAlchemyRecipe(
                 "PURECOPPER",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 17),
                 "oreBasaltCopper",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.EARTH, 1).add(Aspect.ORDER, 1));
 
         registerAlchemyRecipe(
                 "PURECOPPER",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 17),
                 "rawOreCopper",
                 new AspectList().add(Aspect.METAL, 2).add(Aspect.EARTH, 1).add(Aspect.EXCHANGE, 1)
                         .add(Aspect.ORDER, 1));
 
+        refreshResearchPages("PURECOPPER");
         addResearchPage("PURECOPPER", new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PURECOPPER.3")));
 
         registerAlchemyRecipe(
                 "PURETIN",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 18),
                 "oreTin",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
@@ -166,7 +169,7 @@ public class WG_alchemic_tc_clusters {
 
         registerAlchemyRecipe(
                 "PURETIN",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 18),
                 "oreBlackgraniteTin",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
@@ -174,7 +177,7 @@ public class WG_alchemic_tc_clusters {
 
         registerAlchemyRecipe(
                 "PURETIN",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 18),
                 "oreRedgraniteTin",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
@@ -182,7 +185,7 @@ public class WG_alchemic_tc_clusters {
 
         registerAlchemyRecipe(
                 "PURETIN",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 18),
                 "oreMarbleTin",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
@@ -190,7 +193,7 @@ public class WG_alchemic_tc_clusters {
 
         registerAlchemyRecipe(
                 "PURETIN",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 18),
                 "oreBasaltTin",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
@@ -198,17 +201,18 @@ public class WG_alchemic_tc_clusters {
 
         registerAlchemyRecipe(
                 "PURETIN",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 18),
                 "rawOreTin",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.CRYSTAL, 1)
                         .add(Aspect.ORDER, 1));
 
+        refreshResearchPages("PURETIN");
         addResearchPage("PURETIN", new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PURETIN.3")));
 
         registerAlchemyRecipe(
                 "PURESILVER",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 19),
                 "oreSilver",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
@@ -229,44 +233,45 @@ public class WG_alchemic_tc_clusters {
 
         registerAlchemyRecipe(
                 "PURESILVER",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 19),
                 "oreBlackgraniteSilver",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
 
         registerAlchemyRecipe(
                 "PURESILVER",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 19),
                 "oreRedgraniteSilver",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
 
         registerAlchemyRecipe(
                 "PURESILVER",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 19),
                 "oreMarbleSilver",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
 
         registerAlchemyRecipe(
                 "PURESILVER",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 19),
                 "oreBasaltSilver",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
 
         registerAlchemyRecipe(
                 "PURESILVER",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 19),
                 "rawOreSilver",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ENTROPY, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
 
+        refreshResearchPages("PURESILVER");
         addResearchPage("PURESILVER", new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PURESILVER.3")));
 
         registerAlchemyRecipe(
                 "PURELEAD",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 20),
                 "oreLead",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
@@ -287,44 +292,45 @@ public class WG_alchemic_tc_clusters {
 
         registerAlchemyRecipe(
                 "PURELEAD",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 20),
                 "oreBlackgraniteLead",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
 
         registerAlchemyRecipe(
                 "PURELEAD",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 20),
                 "oreRedgraniteLead",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
 
         registerAlchemyRecipe(
                 "PURELEAD",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 20),
                 "oreMarbleLead",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
 
         registerAlchemyRecipe(
                 "PURELEAD",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 20),
                 "oreBasaltLead",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
 
         registerAlchemyRecipe(
                 "PURELEAD",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 20),
                 "rawOreLead",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
 
+        refreshResearchPages("PURELEAD");
         addResearchPage("PURELEAD", new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PURELEAD.3")));
 
         registerAlchemyRecipe(
                 "PUREGOLD",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 31),
                 "oreGold",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
@@ -345,39 +351,40 @@ public class WG_alchemic_tc_clusters {
 
         registerAlchemyRecipe(
                 "PUREGOLD",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 31),
                 "oreBlackgraniteGold",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
 
         registerAlchemyRecipe(
                 "PUREGOLD",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 31),
                 "oreRedgraniteGold",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
 
         registerAlchemyRecipe(
                 "PUREGOLD",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 31),
                 "oreMarbleGold",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
 
         registerAlchemyRecipe(
                 "PUREGOLD",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 31),
                 "oreBasaltGold",
                 new AspectList().add(Aspect.METAL, 3).add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 1));
 
         registerAlchemyRecipe(
                 "PUREGOLD",
-                ".2",
+                "",
                 new ItemStack(ConfigItems.itemNugget, 2, 31),
                 "rawOreGold",
                 new AspectList().add(Aspect.METAL, 2).add(Aspect.EARTH, 1).add(Aspect.GREED, 1).add(Aspect.ORDER, 1));
 
+        refreshResearchPages("PUREGOLD");
         addResearchPage("PUREGOLD", new ResearchPage((CrucibleRecipe) WGContent.recipeList.get("PUREGOLD.3")));
     }
 


### PR DESCRIPTION
I've blacklisted the vanilla Thaumcraft Clusters so that WG doesn't create duplicates of them, but that means they need some special attention to implement the additional recipes that exist.
![image](https://github.com/user-attachments/assets/536f253f-128c-4454-b9b7-6bf1d36ef69a)
The Cinnabar is almost working as intended.
![image](https://github.com/user-attachments/assets/361f2db7-6951-4a29-a2ea-ed439c641fce)
![image](https://github.com/user-attachments/assets/54e86537-de50-401e-93ec-9081d5a470ec)

All this just to: 
fixes [#17825](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17825)
This was complicated to fix Bart...

This is ready for review now.
