### PR TITLE
Fix Vambraces of Steady Progression

### DIFF
--- a/src/main/java/witchinggadgets/common/util/handler/EventHandler.java
+++ b/src/main/java/witchinggadgets/common/util/handler/EventHandler.java
@@ -49,6 +49,7 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.oredict.OreDictionary;
 
 import baubles.api.BaublesApi;
+import baubles.api.expanded.BaubleExpandedSlots;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.common.eventhandler.EventPriority;
@@ -184,9 +185,10 @@ public class EventHandler {
 
     @SubscribeEvent
     public void onPlayerBreaking(PlayerEvent.BreakSpeed event) {
-        if (event.entityPlayer.getItemInUse() != null
-                && event.entityPlayer.getItemInUse().getItem() instanceof ItemMagicalBaubles
-                && event.entityPlayer.getItemInUse().getItemDamage() == 3) {
+        ItemStack gauntletSlot = BaublesApi.getBaubles(event.entityPlayer).getStackInSlot(
+                BaubleExpandedSlots.getIndexesOfAssignedSlotsOfType(BaubleExpandedSlots.gauntletType)[0]);
+        if (gauntletSlot != null && gauntletSlot.getItem() instanceof ItemMagicalBaubles
+                && gauntletSlot.getItemDamage() == 3) {
             Block block = event.entityPlayer.worldObj.getBlock(event.x, event.y, event.z);
             if (!event.entityPlayer.onGround) event.newSpeed *= 5.0F;
             if (event.entityPlayer.isInsideOfMaterial(Material.water)


### PR DESCRIPTION
Worked on this at Dream's request to resolve the server crash issues.

It's also not clear the feature previously worked, it now should be active whenever the `Vambraces of Steady Progression` is in the gauntlet slot.

Note: It could be a good idea to cache the results of `BaubleExpandedSlots.getIndexesOfAssignedSlotsOfType` in PostInit since the answer shouldn't change beyond initialization and we call it often.

### Video demonstration

![after](https://github.com/user-attachments/assets/d9a7f309-875d-4783-98b6-045ca1fac901)
