### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/witchinggadgets/lang/en_US.lang
+++ b/src/main/resources/assets/witchinggadgets/lang/en_US.lang
@@ -1,6 +1,7 @@
 # -- Blocks --
 tile.WG_WallMirror.name=Mirror on the Wall
 tile.WG_VoidWalkway.name=Void Walkway
+tile.WG_StoneDevice.name=Stone Device
 tile.WG_StoneDevice.etherealWall.name=Ethereal Wall
 tile.WG_StoneDevice.magicTileLock.name=Magical Lock
 tile.WG_StoneDevice.obsidianPlate.name=Obsidian Plate
@@ -11,6 +12,7 @@ tile.WG_StoneDevice.sarcophagus.name=Sarcophagus
 tile.WG_StoneDevice.timeStone.name=Ageing Stone
 tile.WG_StoneDevice.blastFurnace.name=Infernal Blast Furnace
 
+tile.WG_WoodenDevice.name=Wooden Device
 tile.WG_WoodenDevice.spinningWheel.name=Spinning Wheel
 tile.WG_WoodenDevice.loom.name=Loom
 tile.WG_WoodenDevice.snowGen.name=Thaumic Snowballer
@@ -21,6 +23,7 @@ tile.WG_WoodenDevice.cuttingTable.name=Cutting Table
 tile.WG_WoodenDevice.saunaStove.name=Thaumic Sauna Stove
 tile.WG_WoodenDevice.labelLibrary.name=Aspect Library
 
+tile.WG_MetalDevice.name=Metal Device
 tile.WG_MetalDevice.essentiaPump.name=Essentia Pump
 tile.WG_MetalDevice.voidmetalBlock.name=Void metal Block
 tile.WG_MetalDevice.terraformer.name=Arcane Terrestrial Reformer
@@ -41,6 +44,7 @@ tile.WG_CustomAir.name=Glimmer of Light
 
 #
 # -- Items --
+item.WG_Material.name=Material
 item.WG_Material.threadSimple.name=Yarn
 item.WG_Material.threadGold.name=Golden Thread
 item.WG_Material.threadThaumium.name=Thaumium Thread
@@ -63,12 +67,14 @@ item.WG_Material.gemstoneDust.name=Gemstone Dust
 
 item.WG_Cluster.name=Native %1$s Cluster
 
+item.WG_Bag.name=Bag
 item.WG_Bag.normal.name=Bag of Tricks
 item.WG_Bag.void.name=Voidlinked Bag
 item.WG_Bag.ender.name=Enderlinked Bag
 item.WG_Bag.hungry.name=Hungry Bag
 
 item.WG_ThaumiumShears.name=Thaumium Shears
+item.WG_MagicFood.name=Magic Food
 item.WG_MagicFood.sweetwart.name=Sweetwart
 item.WG_MagicFood.nethercake.name=Nethercake
 item.WG_MagicFood.brainjerky.name=Brain Jerky
@@ -77,17 +83,21 @@ item.WG_AdvancedRobeLegs.name=Bewitched Leggings
 
 item.WG_AdvancedScribingTools.name=Illuminated Scribing Tools
 
+item.WG_Cloak.name=Cloak
 item.WG_Cloak.standard.name=Cloak
 item.WG_Cloak.storage.name=Cloak of Voluminous Pockets
 item.WG_Cloak.raven.name=Mantle of the Raven
 item.WG_Cloak.spectral.name=Spectral Mantle
 item.WG_Cloak.wolf.name=Wolven Cloak
 
+item.WG_Kama.name=Kama
 item.WG_Kama.standard.name=Kama
 item.WG_Kama.storage.name=Kama of Voluminous Pockets
 item.WG_Kama.raven.name=Kama of the Raven
 item.WG_Kama.spectral.name=Spectral Kama
 item.WG_Kama.wolf.name=Wolven Kama
+
+item.WG_Baubles.name=Bauble
 
 #unused
 item.WG_EliteArmorHelm.ANGELIC_0.name=Ophanic Helm


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.