### PR TITLE
fix gregtech loader check

### DIFF
--- a/src/main/java/witchinggadgets/common/items/ItemInfusedGem.java
+++ b/src/main/java/witchinggadgets/common/items/ItemInfusedGem.java
@@ -199,7 +199,7 @@ public class ItemInfusedGem extends Item implements IInfusedGem {
                             }
             }
             if (aspect.equals(Aspect.EARTH)) {
-                if (!Loader.isModLoaded("gregtech") && mop != null
+                if (!(Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi")) && mop != null
                         && mop.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
                     List<ChunkCoordinates> ores = this.getOres(world, mop.blockX, mop.blockY, mop.blockZ);
                     if (world.isRemote)


### PR DESCRIPTION
Only fixes a loader check that causes problems with GT6 (if this version of wg will ever be standalone anyway), doesn't fix the problematic Optional decorators