### PR TITLE
Ethereal wall fixes

### DIFF
--- a/src/main/java/witchinggadgets/common/blocks/tiles/TileEntityEtherealWall.java
+++ b/src/main/java/witchinggadgets/common/blocks/tiles/TileEntityEtherealWall.java
@@ -1,5 +1,7 @@
 package witchinggadgets.common.blocks.tiles;
 
+import java.util.Objects;
+
 import net.minecraft.block.Block;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -120,5 +122,16 @@ public class TileEntityEtherealWall extends TileEntityWGBase {
         if (renderType == ConfigBlocks.blockMetalDeviceRI) return blockMeta == 9;
         if (renderType == ConfigBlocks.blockCustomOreRI) return blockMeta == 0 || blockMeta == 7;
         return renderType == ConfigBlocks.blockCosmeticOpaqueRI;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof TileEntityEtherealWall that)) return false;
+        return xCoord == that.xCoord && yCoord == that.yCoord && zCoord == that.zCoord;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(xCoord, yCoord, zCoord);
     }
 }

--- a/src/main/java/witchinggadgets/common/blocks/tiles/TileEntityEtherealWall.java
+++ b/src/main/java/witchinggadgets/common/blocks/tiles/TileEntityEtherealWall.java
@@ -65,23 +65,18 @@ public class TileEntityEtherealWall extends TileEntityWGBase {
         // unify where necessary
         if (masterYmax != null && masterYmax != masterOV) {
             masterOV.integrateOtherNet(masterYmax);
-            ((TileEntityEtherealWall) worldObj.getTileEntity(xCoord, yCoord + 1, zCoord)).master = masterOV;
         }
         if (masterZmin != null && masterZmin != masterOV) {
             masterOV.integrateOtherNet(masterZmin);
-            ((TileEntityEtherealWall) worldObj.getTileEntity(xCoord, yCoord, zCoord - 1)).master = masterOV;
         }
         if (masterZmax != null && masterZmax != masterOV) {
             masterOV.integrateOtherNet(masterZmax);
-            ((TileEntityEtherealWall) worldObj.getTileEntity(xCoord, yCoord, zCoord + 1)).master = masterOV;
         }
         if (masterXmin != null && masterXmin != masterOV) {
             masterOV.integrateOtherNet(masterXmin);
-            ((TileEntityEtherealWall) worldObj.getTileEntity(xCoord - 1, yCoord, zCoord)).master = masterOV;
         }
         if (masterXmax != null && masterXmax != masterOV) {
             masterOV.integrateOtherNet(masterXmax);
-            ((TileEntityEtherealWall) worldObj.getTileEntity(xCoord + 1, yCoord, zCoord)).master = masterOV;
         }
 
         return masterOV;

--- a/src/main/java/witchinggadgets/common/blocks/tiles/TileEntityEtherealWall.java
+++ b/src/main/java/witchinggadgets/common/blocks/tiles/TileEntityEtherealWall.java
@@ -63,10 +63,6 @@ public class TileEntityEtherealWall extends TileEntityWGBase {
         else if (masterXmin != null) masterOV = masterXmin;
         else if (masterXmax != null) masterOV = masterXmax;
         // unify where necessary
-        if (masterYmin != null && masterYmin != masterOV) {
-            masterOV.integrateOtherNet(masterYmin);
-            ((TileEntityEtherealWall) worldObj.getTileEntity(xCoord, yCoord - 1, zCoord)).master = masterOV;
-        }
         if (masterYmax != null && masterYmax != masterOV) {
             masterOV.integrateOtherNet(masterYmax);
             ((TileEntityEtherealWall) worldObj.getTileEntity(xCoord, yCoord + 1, zCoord)).master = masterOV;

--- a/src/main/java/witchinggadgets/common/util/EtherealWallMaster.java
+++ b/src/main/java/witchinggadgets/common/util/EtherealWallMaster.java
@@ -37,5 +37,8 @@ public class EtherealWallMaster {
 
     public void integrateOtherNet(EtherealWallMaster net) {
         this.tileMap.addAll(net.tileMap);
+        for (TileEntityEtherealWall other : net.tileMap) {
+            other.master = this;
+        }
     }
 }

--- a/src/main/java/witchinggadgets/common/util/EtherealWallMaster.java
+++ b/src/main/java/witchinggadgets/common/util/EtherealWallMaster.java
@@ -1,8 +1,6 @@
 package witchinggadgets.common.util;
 
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
-import net.minecraft.tileentity.TileEntity;
-
 import witchinggadgets.common.blocks.tiles.TileEntityEtherealWall;
 
 public class EtherealWallMaster {
@@ -26,12 +24,6 @@ public class EtherealWallMaster {
         return true;
     }
 
-    public boolean removeTileFromNet(TileEntityEtherealWall tile) {
-        this.tileMap.remove(tile);
-        tile.master = null;
-        return true;
-    }
-
     /**
      * Disbands Net and sets every Tile's master to null. Allows Tiles to form new nets. Used to allow an Net to be
      * split.
@@ -41,35 +33,6 @@ public class EtherealWallMaster {
             tile.master = null;
         }
         this.tileMap = new ObjectOpenHashSet<>();
-    }
-
-    public TileEntityEtherealWall[] sortTilesByDistanceTo(int x, int y, int z) {
-        TileEntityEtherealWall[] result = new TileEntityEtherealWall[tileMap.size()];
-        int counter = 0;
-        for (TileEntityEtherealWall tile : tileMap) {
-            result[counter] = tile;
-            counter++;
-        }
-        return result;
-    }
-
-    private boolean areTilesAdjacent(TileEntity par1, TileEntity par2) {
-        boolean sameX = par1.xCoord == par2.xCoord;
-        boolean sameY = par1.yCoord == par2.yCoord;
-        boolean sameZ = par1.zCoord == par2.zCoord;
-        if (sameX && sameY) {
-            if (Math.abs(par1.zCoord - par2.zCoord) == 1) return true;
-            return false;
-        }
-        if (sameZ && sameY) {
-            if (Math.abs(par1.xCoord - par2.xCoord) == 1) return true;
-            return false;
-        }
-        if (sameX && sameZ) {
-            if (Math.abs(par1.yCoord - par2.yCoord) == 1) return true;
-            return false;
-        }
-        return false;
     }
 
     public void integrateOtherNet(EtherealWallMaster net) {

--- a/src/main/java/witchinggadgets/common/util/EtherealWallMaster.java
+++ b/src/main/java/witchinggadgets/common/util/EtherealWallMaster.java
@@ -1,18 +1,16 @@
 package witchinggadgets.common.util;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.tileentity.TileEntity;
 
 import witchinggadgets.common.blocks.tiles.TileEntityEtherealWall;
 
 public class EtherealWallMaster {
 
-    public List<TileEntityEtherealWall> tileMap;
+    private ObjectOpenHashSet<TileEntityEtherealWall> tileMap;
 
     public EtherealWallMaster() {
-        this.tileMap = new ArrayList<TileEntityEtherealWall>();
+        this.tileMap = new ObjectOpenHashSet<>();
     }
 
     public boolean isAnyTileInNetPowered() {
@@ -42,7 +40,7 @@ public class EtherealWallMaster {
         for (TileEntityEtherealWall tile : tileMap) {
             tile.master = null;
         }
-        this.tileMap = new ArrayList<TileEntityEtherealWall>();
+        this.tileMap = new ObjectOpenHashSet<>();
     }
 
     public TileEntityEtherealWall[] sortTilesByDistanceTo(int x, int y, int z) {


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20254

It would create hundreds of millions entries in a list until it crashes, I used a hashset to deduplicate.

Also updates ethereal wall logic to make it work reliably. Imagine the following case:

```
    W
W X W
```
If all `W` are walls, and you place one at `X`, then the top right will still only see itself and the bottom connected. My PR fixes this.