### PR TITLE
Fix Gem Cluster Sifting Percentages

### DIFF
--- a/src/main/java/witchinggadgets/common/recipes/other/WG_GT_clusters.java
+++ b/src/main/java/witchinggadgets/common/recipes/other/WG_GT_clusters.java
@@ -238,7 +238,7 @@ public class WG_GT_clusters {
                                                 GTOreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, tGem, 1L),
                                                 GTOreDictUnificator.get(OrePrefixes.gemChipped, aMaterial, tGem, 1L),
                                                 GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, tGem, 1L))
-                                        .outputChances(600, 2400, 9000, 2400, 5600, 7000).duration(80 * SECONDS).eut(30)
+                                        .outputChances(600, 2400, 9000, 2800, 5600, 7000).duration(80 * SECONDS).eut(30)
                                         .addTo(sifterRecipes);
                                 break;
                             }
@@ -287,7 +287,7 @@ public class WG_GT_clusters {
                                                 GTOreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, tGem, 2L),
                                                 GTOreDictUnificator.get(OrePrefixes.gemChipped, aMaterial, tGem, 2L),
                                                 GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, tGem, 2L))
-                                        .outputChances(600, 2400, 9000, 2400, 5600, 7000).duration(160 * SECONDS)
+                                        .outputChances(600, 2400, 9000, 2800, 5600, 7000).duration(160 * SECONDS)
                                         .eut(30).addTo(sifterRecipes);
                                 break;
                             }


### PR DESCRIPTION
### Changes:
- The WG gem clusters are supposed to sift with double the output percentage of a regular ore's sifting percent, but there was a mistaken inconsistency of 14 * 2 = 24 instead of 28. This just fixes that. (Also I guess technically speaking it's a buff)

This was pointed out here https://discord.com/channels/181078474394566657/181078474394566657/1408150734704476190

### Pre-Fix Example: (Checkout specifically the bottom left flawed diamond percentages)
<img width="513" height="870" alt="image" src="https://github.com/user-attachments/assets/f4b0ea0c-61db-4553-adbd-06452a8e5da9" />
