### PR TITLE
Switch to MV parts

### DIFF
--- a/src/main/java/witchinggadgets/common/recipes/arcane/WG_arcane_calculator.java
+++ b/src/main/java/witchinggadgets/common/recipes/arcane/WG_arcane_calculator.java
@@ -26,9 +26,9 @@ public class WG_arcane_calculator {
                     's',
                     "stickThaumium",
                     'r',
-                    ItemList.Sensor_HV.get(1L),
+                    ItemList.Sensor_MV.get(1L),
                     'b',
-                    "circuitAdvanced",
+                    "circuitGood",
                     'g',
                     new ItemStack(ConfigBlocks.blockStoneDevice, 1, 2));
         } else {


### PR DESCRIPTION
See discussion in discord: https://discord.com/channels/181078474394566657/401118216228831252/1398128689085943880

HV components for the abacus is too expensive, MV fits with the other early magic utilities.