### PR TITLE
Add a NBT save on GUI close for Bag of Tricks

### DIFF
--- a/src/main/java/witchinggadgets/common/gui/ContainerBag.java
+++ b/src/main/java/witchinggadgets/common/gui/ContainerBag.java
@@ -120,4 +120,14 @@ public class ContainerBag extends Container {
             this.player.setCurrentItemOrArmor(0, this.pouch);
         }
     }
+
+    @Override
+    public void onContainerClosed(EntityPlayer player) {
+        // also save the items NBT on close in case something else
+        // (e.g. Bogo Sorter) messed with it without us knowing
+        super.onContainerClosed(player);
+        if (!this.player.worldObj.isRemote && this.isHoldingPouch()) {
+            ItemBag.setStoredItems(this.pouch, this.input.stackList);
+        }
+    }
 }


### PR DESCRIPTION
Bag of Tricks only saves its items NBT on clicks of the container GUI `slotClick()`. This adds a NBT save on GUI close in case something else (BogoSorter) messed with the item stack list without us knowing. The patch couldn't be made as a mixin inject for the vanilla obfuscated method `onContainerClosed` in a non-obfuscated derived `ContainerBag` class (can it?)

I guess the current behavior is to save on content change expecting the Bag item to disappear from player inventory at any time, but BogoSorter doesn't have good way for a callback after sorting so this is the stopgap fix for now.

The Cloak already have this NBT save. Related: https://github.com/GTNewHorizons/InventoryBogoSorter/pull/218

## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
