### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/witchinggadgets/client/gui/GuiCuttingTable.java
+++ b/src/main/java/witchinggadgets/client/gui/GuiCuttingTable.java
@@ -57,8 +57,8 @@ public class GuiCuttingTable extends GuiContainer {
             int old = this.tile.targetGemCut;
             if (mX > 106 && mX < 117) this.tile.targetGemCut++;
             if (mX > 59 && mX < 70) this.tile.targetGemCut--;
-            if (this.tile.targetGemCut < 0) this.tile.targetGemCut = (byte) (ItemInfusedGem.GemCut.values().length - 1);
-            else if (this.tile.targetGemCut >= ItemInfusedGem.GemCut.values().length) this.tile.targetGemCut = 0;
+            if (this.tile.targetGemCut < 0) this.tile.targetGemCut = (byte) (ItemInfusedGem.GemCut.VALUES.length - 1);
+            else if (this.tile.targetGemCut >= ItemInfusedGem.GemCut.VALUES.length) this.tile.targetGemCut = 0;
 
             if (this.tile.targetGemCut != old) WitchingGadgets.packetHandler
                     .sendToServer(new MessageCutGem(this.inventorySlots.windowId, this.tile.targetGemCut));

--- a/src/main/java/witchinggadgets/common/items/ItemInfusedGem.java
+++ b/src/main/java/witchinggadgets/common/items/ItemInfusedGem.java
@@ -51,7 +51,7 @@ import witchinggadgets.common.util.Utilities;
 
 public class ItemInfusedGem extends Item implements IInfusedGem {
 
-    IIcon[] icons = new IIcon[GemCut.values().length];
+    IIcon[] icons = new IIcon[GemCut.VALUES.length];
 
     public ItemInfusedGem() {
         super();
@@ -769,7 +769,7 @@ public class ItemInfusedGem extends Item implements IInfusedGem {
     @Override
     public void registerIcons(IIconRegister ir) {
         for (int i = 0; i < icons.length; i++) this.icons[i] = ir
-                .registerIcon("witchinggadgets:infusedGem_" + GemCut.values()[i].toString().toLowerCase());
+                .registerIcon("witchinggadgets:infusedGem_" + GemCut.VALUES[i].toString().toLowerCase());
     }
 
     @Override
@@ -843,10 +843,12 @@ public class ItemInfusedGem extends Item implements IInfusedGem {
         // STEP,
         // ROSE,
         OVAL;
-
+        
+        public static final GemCut[] VALUES = values();
+        
         public static GemCut getValue(byte b) {
-            if (b >= 0 && b < values().length) return values()[b];
-            return values()[0];
+            if (b >= 0 && b < VALUES.length) return VALUES[b];
+            return VALUES[0];
         }
     }
 

--- a/src/main/java/witchinggadgets/common/items/ItemInfusedGem.java
+++ b/src/main/java/witchinggadgets/common/items/ItemInfusedGem.java
@@ -768,8 +768,8 @@ public class ItemInfusedGem extends Item implements IInfusedGem {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister ir) {
-        for (int i = 0; i < icons.length; i++) this.icons[i] = ir
-                .registerIcon("witchinggadgets:infusedGem_" + GemCut.VALUES[i].toString().toLowerCase());
+        for (int i = 0; i < icons.length; i++)
+            this.icons[i] = ir.registerIcon("witchinggadgets:infusedGem_" + GemCut.VALUES[i].toString().toLowerCase());
     }
 
     @Override
@@ -843,9 +843,9 @@ public class ItemInfusedGem extends Item implements IInfusedGem {
         // STEP,
         // ROSE,
         OVAL;
-        
+
         public static final GemCut[] VALUES = values();
-        
+
         public static GemCut getValue(byte b) {
             if (b >= 0 && b < VALUES.length) return VALUES[b];
             return VALUES[0];


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
